### PR TITLE
1.3.1-alpha

### DIFF
--- a/accounts/tests/test_utilities.py
+++ b/accounts/tests/test_utilities.py
@@ -4,6 +4,7 @@ from core.utilities.tests import TestMessageMixin
 
 from accounts.factories import UserFactory
 from variant.factories import VariantFactory
+from variant.models import Variant
 
 import dataset
 from dataset.factories import ScoreSetFactory
@@ -179,6 +180,13 @@ class TestPublish(TestCase, TestMessageMixin):
         scoreset.add_administrators(self.user)
         publish_dataset(scoreset)
         self.assertFalse(publish(scoreset.urn, self.create_request()))
+        
+    @mock.patch.object(Variant, 'bulk_create_urns', return_value=['a', 'b', 'c'])
+    def test_calls_create_bulk_urns_with_reset_counter_as_true(self, patch):
+        scoreset = self.create_scoreset()
+        scoreset.add_administrators(self.user)
+        publish_dataset(scoreset)
+        patch.assert_called_with(*(3, scoreset), reset_counter=True)
     
     @mock.patch('dataset.tasks.publish_scoreset.submit_task', return_value=(True, None))
     def test_sets_status_as_processing(self, patch):

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -272,11 +272,11 @@ class TestFormatCSVRows(TestCase):
     def test_dicts_include_urn(self):
         vs = [VariantFactory() for _ in range(5)]
         rows = views.format_csv_rows(
-            vs, columns=['score', 'urn', ],
+            vs, columns=['score', 'accession', ],
             dtype=constants.variant_score_data
         )
         for v, row in zip(vs, rows):
-            self.assertEqual(v.urn, row['urn'])
+            self.assertEqual(v.urn, row['accession'])
 
     def test_dicts_include_nt_hgvs(self):
         vs = [VariantFactory() for _ in range(5)]
@@ -343,7 +343,7 @@ class TestFormatResponse(TestCase):
         response = views.format_response(
             self.response, self.instance, dtype='scores')
         content = response.content.decode()
-        self.assertIn("# URN: {}".format(self.instance.urn), content)
+        self.assertIn("# Accession: {}".format(self.instance.urn), content)
         self.assertIn("# Downloaded (UTC):", content)
         self.assertIn("# Licence: {}".format(
             self.instance.licence.long_name), content)
@@ -368,7 +368,7 @@ class TestFormatResponse(TestCase):
 
         called_dtype = patch.call_args[1]['dtype']
         called_columns = patch.call_args[1]['columns']
-        expected_columns = ['urn'] + self.instance.score_columns
+        expected_columns = ['accession'] + self.instance.score_columns
         self.assertEqual(called_dtype, constants.variant_score_data)
         self.assertListEqual(called_columns, expected_columns)
 
@@ -386,7 +386,7 @@ class TestFormatResponse(TestCase):
 
         called_dtype = patch.call_args[1]['dtype']
         called_columns = patch.call_args[1]['columns']
-        expected_columns = ['urn'] + self.instance.count_columns
+        expected_columns = ['accession'] + self.instance.count_columns
         self.assertEqual(called_dtype, constants.variant_count_data)
         self.assertListEqual(called_columns, expected_columns)
 

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,4 @@
+import string
 import csv
 from datetime import datetime
 
@@ -191,6 +192,13 @@ def format_csv_rows(variants, columns, dtype):
     return rowdicts
 
 
+def urn_number(variant):
+    number = variant.urn.split('#')[-1]
+    if not str.isdigit(number):
+        return 0
+    return int(number)
+    
+
 def format_response(response, scoreset, dtype):
     """
     Writes the CSV response by formatting each variant into a row including
@@ -217,7 +225,7 @@ def format_response(response, scoreset, dtype):
     ])
     
     variants = sorted(
-        scoreset.children.all(), key=lambda v: int(v.urn.split('#')[-1]))
+        scoreset.children.all(), key=lambda v: urn_number(v))
         
     if dtype == 'scores':
         columns = ['urn', ] + scoreset.score_columns

--- a/api/views.py
+++ b/api/views.py
@@ -218,7 +218,7 @@ def format_response(response, scoreset, dtype):
     `HttpResponse`
     """
     response.writelines([
-        "# URN: {}\n".format(scoreset.urn),
+        "# Accession: {}\n".format(scoreset.urn),
         "# Downloaded (UTC): {}\n".format(datetime.utcnow()),
         "# Licence: {}\n".format(scoreset.licence.long_name),
         "# Licence URL: {}\n".format(scoreset.licence.link),

--- a/api/views.py
+++ b/api/views.py
@@ -184,7 +184,7 @@ def format_csv_rows(variants, columns, dtype):
                 data[column_key] = str(variant.hgvs_nt)
             elif column_key == constants.hgvs_pro_column:
                 data[column_key] = str(variant.hgvs_pro)
-            elif column_key == 'urn':
+            elif column_key == 'accession':
                 data[column_key] = str(variant.urn)
             else:
                 data[column_key] = str(variant.data[dtype][column_key])
@@ -228,10 +228,10 @@ def format_response(response, scoreset, dtype):
         scoreset.children.all(), key=lambda v: urn_number(v))
         
     if dtype == 'scores':
-        columns = ['urn', ] + scoreset.score_columns
+        columns = ['accession', ] + scoreset.score_columns
         type_column = constants.variant_score_data
     elif dtype == 'counts':
-        columns = ['urn', ] + scoreset.count_columns
+        columns = ['accession', ] + scoreset.count_columns
         type_column = constants.variant_count_data
     else:
         raise ValueError(

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -130,7 +130,7 @@ class BaseTask(Task):
         return task
 
     def submit_task(self, args=None, kwargs=None, async_options=None,
-                    request=None):
+                    request=None, countdown=30):
         """
         Calls `task.apply_async` and handles any connection errors by
         logging the error to the `django` default log and saving the
@@ -148,6 +148,8 @@ class BaseTask(Task):
             Additional kwargs that `apply_async` accepts.
         request : Request, optional. Default: None
             Request object from the view calling this function.
+        countdown : int
+            Delay before executing celery task.
 
         Returns
         -------
@@ -158,7 +160,7 @@ class BaseTask(Task):
             async_options = {}
         try:
             return True, self.apply_async(
-                args=args, kwargs=kwargs, **async_options)
+                args=args, kwargs=kwargs, countdown=countdown, **async_options)
         except kombu_errors as e:
             logger.exception(error_message.format(
                 name=self.name, exc_name=e.__class__.__name__))

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -130,7 +130,7 @@ class BaseTask(Task):
         return task
 
     def submit_task(self, args=None, kwargs=None, async_options=None,
-                    request=None, countdown=30):
+                    request=None, countdown=10):
         """
         Calls `task.apply_async` and handles any connection errors by
         logging the error to the `django` default log and saving the

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -130,7 +130,7 @@ class TestFailedTaskModel(TestCase):
         task.retry_and_delete()
         patch.assert_called()
         self.assertEqual(patch.call_args[1],
-                         {'args': (), 'kwargs': kwargs, 'countdown': 30})
+                         {'args': (), 'kwargs': kwargs, 'countdown': 10})
         self.assertEqual(models.FailedTask.objects.count(), 0)
 
     def test_inline_retry_does_not_delete_if_failure(self):

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -1,4 +1,7 @@
 import json
+import io
+
+import pandas as pd
 
 from django.test import TestCase, mock
 
@@ -46,6 +49,28 @@ class TestFailedTaskModel(TestCase):
         )
         self.assertIsNone(task.args)
         self.assertIsNone(task.kwargs)
+        
+    def test_instantiate_supports_dataframes_in_kwargs_and_args(self):
+        df = pd.DataFrame({'x': [1,2,3], 'y': [3,4,5]})
+        task = models.FailedTask.instantiate_task(
+            name='add',
+            full_name='core.tasks.add',
+            args=[df, ],
+            kwargs={'count_records': df},
+            exc=Exception("This is a test"),
+            traceback=None,
+            task_id="1",
+            user=None,
+        )
+        
+        handle = io.StringIO()
+        df.to_json(handle, orient='records')
+        handle.seek(0)
+        expected = handle.read()
+        
+        self.assertEqual(task.args, json.dumps([expected,]))
+        self.assertEqual(task.kwargs, json.dumps(
+            {'count_records': expected}, sort_keys=True))
         
     def test_update_or_create_creates_new_task(self):
         task, created = models.FailedTask.update_or_create(
@@ -105,7 +130,7 @@ class TestFailedTaskModel(TestCase):
         task.retry_and_delete()
         patch.assert_called()
         self.assertEqual(patch.call_args[1],
-                         {'args': (), 'kwargs': kwargs})
+                         {'args': (), 'kwargs': kwargs, 'countdown': 30})
         self.assertEqual(models.FailedTask.objects.count(), 0)
 
     def test_inline_retry_does_not_delete_if_failure(self):
@@ -144,6 +169,33 @@ class TestFailedTaskModel(TestCase):
             name='add',
             full_name='core.tasks.add',
             args=[],
+            kwargs=kwargs,
+            exc=Exception("This is a test"),
+            traceback=None,
+            task_id="1",
+            user=None,
+        )
+        self.assertEqual(task.find_existing(), existing)
+
+    def test_can_find_existing_task_when_kwargs_has_df(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [3, 4, 5]})
+        kwargs = {'a': 1, 'b': 2, 'df': df}
+        existing = models.FailedTask.instantiate_task(
+            name='add',
+            full_name='core.tasks.add',
+            args=[df,],
+            kwargs=kwargs,
+            exc=Exception("This is a test"),
+            traceback=None,
+            task_id="1",
+            user=None,
+        )
+        existing.save()
+
+        task = models.FailedTask.instantiate_task(
+            name='add',
+            full_name='core.tasks.add',
+            args=[df, ],
             kwargs=kwargs,
             exc=Exception("This is a test"),
             traceback=None,

--- a/data/main/site_info.json
+++ b/data/main/site_info.json
@@ -6,5 +6,5 @@
     "md_privacy": "",
     "md_terms": "",
     "md_usage_guide": "",
-    "version": "1.3.0-alpha"
+    "version": "1.3.1-alpha"
 }

--- a/dataset/forms/scoreset.py
+++ b/dataset/forms/scoreset.py
@@ -1,4 +1,5 @@
 import json
+import io
 from enum import Enum
 
 import pandas as pd
@@ -6,6 +7,7 @@ import pandas as pd
 from django import forms as forms
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.utils.translation import ugettext
 
 from core.mixins import NestedEnumMixin
@@ -13,9 +15,7 @@ from core.utilities import readable_null_values
 
 from main.models import Licence
 
-from variant.validators import (
-    validate_variant_rows, validate_scoreset_columns_match_variant
-)
+from variant.validators import validate_variant_rows
 
 from dataset import constants as constants
 from ..forms.base import DatasetModelForm
@@ -295,6 +295,13 @@ class ScoreSetForm(DatasetModelForm):
         if meta_file is None:
             return {}
         try:
+            
+            if isinstance(meta_file, InMemoryUploadedFile):
+                content = meta_file.read()
+                if isinstance(content, bytes):
+                    content = content.decode()
+                meta_file = io.StringIO(content)
+            
             dict_ = json.load(meta_file)
             return dict_
         except ValueError as error:

--- a/dataset/utilities.py
+++ b/dataset/utilities.py
@@ -106,7 +106,8 @@ def publish_dataset(dataset, user=None):
             dataset.experiment)
         scoreset = models.scoreset.assign_public_urn(
             dataset)
-        urns = Variant.bulk_create_urns(scoreset.children.count(), scoreset)
+        urns = Variant.bulk_create_urns(
+            scoreset.children.count(), scoreset, reset_counter=True)
         for urn, child in zip(urns, scoreset.children.all()):
             child.urn = urn
             child.save()

--- a/dataset/views/scoreset.py
+++ b/dataset/views/scoreset.py
@@ -2,7 +2,6 @@ import logging
 
 from django.db import transaction
 from django.http import JsonResponse
-from django.conf import settings
 
 from accounts.permissions import PermissionTypes
 

--- a/dataset/views/scoreset.py
+++ b/dataset/views/scoreset.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from django.db import transaction
 from django.http import JsonResponse
@@ -30,6 +31,21 @@ from .base import (
 )
 
 logger = logging.getLogger("django")
+
+
+def fire_task(request, scoreset, task_kwargs):
+    logger.info("Submitting task from {} for {} to Celery.".format(
+        request.user, scoreset.urn
+    ))
+    success, _ = create_variants.submit_task(
+        kwargs=task_kwargs, request=request)
+    logger.info("Submission to celery from {} for {}: {}".format(
+        request.user, scoreset.urn, success
+    ))
+    if not success:
+        scoreset.processing_state = constants.failed
+        scoreset.save()
+
 
 
 class ScoreSetDetailView(AjaxView, DatasetModelView):
@@ -158,6 +174,8 @@ class ScoreSetCreateView(ScoreSetAjaxMixin, CreateDatasetModelView):
                     self.kwargs['experiment'] = experiment
         return super().dispatch(request, *args, **kwargs)
 
+
+    
     @transaction.atomic
     def save_forms(self, forms):
         scoreset_form = forms['scoreset']
@@ -192,11 +210,10 @@ class ScoreSetCreateView(ScoreSetAjaxMixin, CreateDatasetModelView):
         if ensembl_offset:
             targetgene.ensembl_id = ensembl_offset.identifier
         targetgene.save()
-
+            
         # Call celery task after all the above has successfully completed
         if scoreset_form.has_variants():
             scoreset.processing_state = constants.processing
-            scoreset.save()
             scores_rs, counts_rs, index = scoreset_form.serialize_variants()
             task_kwargs = {
                 "user_pk": self.request.user.pk,
@@ -206,14 +223,14 @@ class ScoreSetCreateView(ScoreSetAjaxMixin, CreateDatasetModelView):
                 "scores_records": scores_rs,
                 "counts_records": counts_rs,
             }
-            logger.info("Submitting task from {} for {} to Celery.".format(
-                self.request.user, scoreset.urn
-            ))
-            success, _ = create_variants.submit_task(
-                kwargs=task_kwargs, request=self.request)
-            logger.info("Submission to celery from {} for {}: {}".format(
-                self.request.user, scoreset.urn, success
-            ))
+            
+            call_create = partial(
+                fire_task,
+                request=self.request,
+                scoreset=scoreset,
+                task_kwargs=task_kwargs
+            )
+            transaction.on_commit(call_create)
 
         scoreset.save()
         scoreset.add_administrators(self.request.user)
@@ -316,7 +333,6 @@ class ScoreSetEditView(ScoreSetAjaxMixin, UpdateDatasetModelView):
         # Call celery task after all the above has successfully completed
         if scoreset_form.has_variants():
             scoreset.processing_state = constants.processing
-            scoreset.save()
             scores_rs, counts_rs, index = scoreset_form.serialize_variants()
             task_kwargs = {
                 "user_pk": self.request.user.pk,
@@ -326,16 +342,14 @@ class ScoreSetEditView(ScoreSetAjaxMixin, UpdateDatasetModelView):
                 "scores_records": scores_rs,
                 "counts_records": counts_rs,
             }
+            call_create = partial(
+                fire_task,
+                request=self.request,
+                scoreset=scoreset,
+                task_kwargs=task_kwargs
+            )
+            transaction.on_commit(call_create)
             
-            logger.info("Submitting task from {} for {} to Celery".format(
-                self.request.user, scoreset.urn
-            ))
-            success, _ = create_variants.submit_task(
-                kwargs=task_kwargs, request=self.request)
-            logger.info("Submission to celery from {} for {}: {}".format(
-                self.request.user, scoreset.urn, success
-            ))
-
         scoreset.save()
         track_changes(instance=scoreset, user=self.request.user)
         return forms

--- a/main/management/commands/renumber.py
+++ b/main/management/commands/renumber.py
@@ -1,0 +1,39 @@
+import sys
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from dataset.models.scoreset import ScoreSet
+from variant.models import Variant
+
+def get_number(variant):
+    return int(variant.urn.split('#')[-1])
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--urn', type=str, help="Dataset URN",)
+    
+    @transaction.atomic
+    def handle(self, *args, **kwargs):
+        urn = kwargs.get('urn', None)
+        if urn:
+            scoreset = ScoreSet.objects.get(urn=urn)
+        else:
+            raise ValueError("A valid URN is required.")
+
+        scoreset.last_child_value = 0
+        variants = sorted(scoreset.children.all(), key=lambda v: get_number(v))
+        urns = Variant.bulk_create_urns(scoreset.children.count(), scoreset)
+        sys.stdout.write("Saved urns {}, ..., {}.\n".format(
+            ', '.join(urns[0:3]), urns[-1]))
+        
+        for urn, variant in zip(urns, variants):
+            variant.urn = urn
+            variant.save()
+        
+        scoreset.last_child_value = len(variants)
+        scoreset.save()
+        sys.stdout.write('Updated last child value to {}.\n'.format(
+            scoreset.last_child_value))

--- a/main/management/commands/renumber.py
+++ b/main/management/commands/renumber.py
@@ -26,12 +26,13 @@ class Command(BaseCommand):
         scoreset.last_child_value = 0
         variants = sorted(scoreset.children.all(), key=lambda v: get_number(v))
         urns = Variant.bulk_create_urns(scoreset.children.count(), scoreset)
-        sys.stdout.write("Saved urns {}, ..., {}.\n".format(
+        sys.stdout.write("Created urns {}, ..., {}.\n".format(
             ', '.join(urns[0:3]), urns[-1]))
         
         for urn, variant in zip(urns, variants):
             variant.urn = urn
             variant.save()
+        sys.stdout.write("Saved new urns to database.\n")
         
         scoreset.last_child_value = len(variants)
         scoreset.save()

--- a/variant/models.py
+++ b/variant/models.py
@@ -158,14 +158,15 @@ class Variant(UrnModel):
         return parent.variants.count()
 
     @staticmethod
-    def bulk_create_urns(n, parent):
-        start_value = parent.last_child_value
+    def bulk_create_urns(n, parent, reset_counter=False):
+        start_value = 0 if reset_counter else parent.last_child_value
         parent_urn = parent.urn
         child_urns = [
             "{}#{}".format(parent_urn, start_value + (i + 1))
             for i in range(n)
         ]
-        parent.last_child_value += n
+        current_value = start_value + n
+        parent.last_child_value = current_value
         return child_urns
 
     @property

--- a/variant/tests/test_models.py
+++ b/variant/tests/test_models.py
@@ -78,7 +78,14 @@ class TestVariant(TestCase):
             
     def test_bulk_create_urns_updates_parent_last_child_value(self):
         parent = ScoreSetFactory()
+        parent.last_child_value = 100
         Variant.bulk_create_urns(10, parent)
+        self.assertEqual(parent.last_child_value, 110)
+        
+    def test_bulk_create_urns_resets_parent_value_if_true(self):
+        parent = ScoreSetFactory()
+        parent.last_child_value = 100
+        Variant.bulk_create_urns(10, parent, reset_counter=True)
         self.assertEqual(parent.last_child_value, 10)
     
     @mock.patch.object(Variant, 'bulk_create_urns', return_value=['',])


### PR DESCRIPTION
Major
-------
- Fixed bug where publishing would not reset the variant URN starting index
- Fixed issue creating race condition between celery and django db commits
- Fixed issue reading bytes object into json

Minor
------
- Added countdown on celery apply_async
- Renamed `urn` to `accession` in CSV files
- Added command to renumber datasets from 1  